### PR TITLE
Download Command finished

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.35", features = ["derive"] }
-ffsend-api = "0.7.3"
+ffsend-api = {version = "0.7.3", features = ["send3"]}
 url = "2"

--- a/README.md
+++ b/README.md
@@ -2,10 +2,18 @@
 A secure file sharing cli written in Rust.
 
 
-I fixed and completed the upload command.
 
-Added a new upload subcommand using clap to handle file uploads via the ffsend-api crate.
+Update Logs:
+April 17th - Added a new upload subcommand using clap to handle file uploads via the ffsend-api crate.
 The actual logic for the upload is located in a separate commands/upload.rs module to keep the codebase clean and modular.
 In main.rs, we parse the CLI input and send to the correct subcommand (Upload) by importing the UploadArgs and calling upload_file_cmd.
 use command to upload
 cargo run -- upload <your_path>
+
+April 23rd - Added the download command. 
+    1.  Parse the input URL into a RemoteFile descriptor using RemoteFile::parse_url.
+	2.	Fetch metadata (via the Metadata action) to retrieve the original filename from the ffsend service.
+	3.	Construct the local target path using the fetched filename instead of a placeholder.
+	4.	Pass the metadata response into the Download action to avoid redundant metadata calls.
+	5.	Clean up imports to include the new metadata action types.
+Command: cargo run -- download <URL>

--- a/README.md
+++ b/README.md
@@ -1,19 +1,2 @@
 # Cryo
 A secure file sharing cli written in Rust.
-
-
-
-Update Logs:
-April 17th - Added a new upload subcommand using clap to handle file uploads via the ffsend-api crate.
-The actual logic for the upload is located in a separate commands/upload.rs module to keep the codebase clean and modular.
-In main.rs, we parse the CLI input and send to the correct subcommand (Upload) by importing the UploadArgs and calling upload_file_cmd.
-use command to upload
-cargo run -- upload <your_path>
-
-April 23rd - Added the download command. 
-    1.  Parse the input URL into a RemoteFile descriptor using RemoteFile::parse_url.
-	2.	Fetch metadata (via the Metadata action) to retrieve the original filename from the ffsend service.
-	3.	Construct the local target path using the fetched filename instead of a placeholder.
-	4.	Pass the metadata response into the Download action to avoid redundant metadata calls.
-	5.	Clean up imports to include the new metadata action types.
-Command: cargo run -- download <URL>

--- a/src/commands/download.rs
+++ b/src/commands/download.rs
@@ -1,0 +1,56 @@
+use clap::Args;
+use ffsend_api::{
+    action::download::Download,
+    api::Version,
+    client::ClientConfigBuilder,
+    file::remote_file::RemoteFile,
+};
+use ffsend_api::action::metadata::{Metadata as MetadataAction, MetadataResponse};
+use url::Url;
+use std::path::PathBuf;
+
+#[derive(Args)]
+pub struct DownloadArgs {
+    pub url: String,
+}
+
+/// download subcommand logiic
+pub fn download_file_cmd(args: DownloadArgs) {
+    match download_file(args.url) {
+        Ok(file_path) => {
+            println!("Downloaded to: {}", file_path.display());
+        }
+        Err(e) => {
+            eprintln!("Download failed: {}", e);
+        }
+    }
+}
+
+fn download_file(url: String) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let client_config = ClientConfigBuilder::default().build()?;
+    let client = client_config.client(true);
+    let version = Version::V3;
+
+    let url = Url::parse(&url)?;
+    let file = RemoteFile::parse_url(url.clone(), None)?;
+
+    // fetch metadata to get the original file name
+    let metadata_response: MetadataResponse = MetadataAction::new(&file, None, true)
+        .invoke(&client)?;
+    let file_name = metadata_response.metadata().name();
+    let target_path: PathBuf = std::env::current_dir()?.join(file_name);
+
+    // build download action with the fetched metadata to avoid refetching
+    let download = Download::new(
+        version,
+        &file,
+        target_path.clone(),
+        // TODO: password might be an issue if a user has uploaded w password. Current action doesn't account of it. 
+        None, 
+        true,
+        Some(metadata_response),
+    );
+
+    download.invoke(&client, None)?;
+    Ok(target_path)
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,1 +1,2 @@
 pub mod upload;
+pub mod download;

--- a/src/commands/upload.rs
+++ b/src/commands/upload.rs
@@ -53,7 +53,8 @@ fn upload_file(path: PathBuf) -> Result<RemoteFile, Error> {
     let params = {
         let params = ParamsDataBuilder::default()
             .download_limit(Some(5))
-            .expiry_time(Some(604_800))
+            // TODO: Debug why expiry time is causing issues
+            .expiry_time(Some(259_800))
             .build()
             .unwrap();
 

--- a/src/commands/upload.rs
+++ b/src/commands/upload.rs
@@ -6,6 +6,7 @@ use ffsend_api::{
     api::Version,
     client::ClientConfigBuilder,
     file::remote_file::RemoteFile,
+    action::params::ParamsData,
 };
 use url::Url;
 
@@ -37,13 +38,16 @@ fn upload_file(path: PathBuf) -> Result<RemoteFile, Error> {
 
     let version = Version::V3;
 
+    // expiry time is in seconds, 605800 = 7 days
+    let params = ParamsData::from(Some(5), Some(604800)); 
+
     let upload = Upload::new(
         version,
         Url::parse("https://send.vis.ee/").expect("Invalid URL"),
         path,
-        None, // password: optional
-        None, // expiry: optional
-        None, // download limit: optional
+        None, 
+        None, 
+        Some(params), 
     );
 
     Upload::invoke(upload, &client, None)

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,14 +13,16 @@ struct Cli {
 enum Commands {
     #[clap(alias = "u", alias = "up")]
     Upload(commands::upload::UploadArgs),
+
+    #[clap(alias = "d", alias = "down")]
+    Download(commands::download::DownloadArgs),
 }
 
 fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Upload(args) => {
-            commands::upload::upload_file_cmd(args);
-        }
+        Commands::Upload(args) => commands::upload::upload_file_cmd(args),
+        Commands::Download(args) => commands::download::download_file_cmd(args),
     }
 }

--- a/testUpload.txt
+++ b/testUpload.txt
@@ -1,7 +1,0 @@
-Testing for Upload command
-path url:
-al: (change for yours)
-/Users/alnaheyan/Desktop/projects/Cryo/testUpload.txt
-
-relative Path:
-testUpload.txt


### PR DESCRIPTION
## Description
Added the download command for Cryo. It fetches the URL and creates a remote file then downloads the metadata (file name and etc). The endpoint file should be placed in the same directory as the project root directory. 

## Changes Made
- Parse the input URL into a RemoteFile descriptor using RemoteFile::parse_url.
- Fetch metadata (via the Metadata action) to retrieve the original filename from the ffsend service
- Construct the local target path using the fetched filename instead of a placeholder.
- Pass the metadata response into the Download action to avoid redundant metadata calls.
- Clean up imports to include the new metadata action types.

## Command to run: 
`cargo run -- download <URL>`

