### PR TITLE
feat: add info subcommand to display metadata for shared file URLs

### DIFF
--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -1,0 +1,36 @@
+use clap::Args;
+use ffsend_api::{
+    action::metadata::{Metadata as MetadataAction, MetadataResponse},
+    client::ClientConfigBuilder,
+    file::remote_file::RemoteFile,
+};
+use url::Url;
+
+#[derive(Args)]
+/// Show metadata for a shared file URL
+pub struct InfoArgs {
+    /// URL of the file to show info for
+    pub url: String,
+}
+
+/// Execute the info subcommand: fetch and display metadata
+pub fn info_file_cmd(args: InfoArgs) {
+    match info_file(args.url) {
+        Ok(resp) => println!("{:#?}", resp.metadata()),
+        Err(e) => eprintln!("Info failed: {}", e),
+    }
+}
+
+/// Internal helper to perform the metadata request
+fn info_file(url: String) -> Result<MetadataResponse, Box<dyn std::error::Error>> {
+    // build HTTP client
+    let client = ClientConfigBuilder::default().build()?.client(true);
+
+    // parse URL and create RemoteFile object
+    let url = Url::parse(&url)?;
+    let file = RemoteFile::parse_url(url, None)?;
+
+    // invoke metadata action without version key
+    let resp = MetadataAction::new(&file, None, true).invoke(&client)?;
+    Ok(resp)
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,2 +1,3 @@
-pub mod upload;
 pub mod download;
+pub mod info;
+pub mod upload;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,14 @@
 mod commands;
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 
 #[derive(Parser)]
-#[clap(name = "ffsend", version = "0.1", author = "al", about = "A CLI for file sharing using ffsend")]
+#[clap(
+    name = "ffsend",
+    version = "0.1",
+    author = "al",
+    about = "A CLI for file sharing using ffsend"
+)]
 struct Cli {
     #[clap(subcommand)]
     command: Commands,
@@ -16,6 +21,15 @@ enum Commands {
 
     #[clap(alias = "d", alias = "down")]
     Download(commands::download::DownloadArgs),
+
+    #[clap(alias = "i")]
+    Info(commands::info::InfoArgs),
+
+    /// Display help information
+    Help {
+        /// Subcommand to display help for
+        command: Option<String>,
+    },
 }
 
 fn main() {
@@ -24,5 +38,20 @@ fn main() {
     match cli.command {
         Commands::Upload(args) => commands::upload::upload_file_cmd(args),
         Commands::Download(args) => commands::download::download_file_cmd(args),
+        Commands::Info(args) => commands::info::info_file_cmd(args),
+        Commands::Help { command } => {
+            let mut cmd = Cli::command();
+            if let Some(sub) = command {
+                if let Some(sc) = cmd.find_subcommand_mut(&sub) {
+                    sc.print_help().unwrap();
+                } else {
+                    eprintln!("Unknown command '{}', showing general help:", sub);
+                    cmd.print_help().unwrap();
+                }
+            } else {
+                cmd.print_help().unwrap();
+            }
+            println!();
+        }
     }
 }


### PR DESCRIPTION
## Description
Added the info subcommand to display metadata for shared file URLs.